### PR TITLE
Load GA analytics script into `head` content placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,24 @@ export default {
 
 ### Setup Google Analytics snippet
 
-```html
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+To setup Google Universal Analytics, you have to create `analyticsInsights` key in your
+configuration environment.js:
 
-  // Replace UA-XXXX-Y with your Tracking ID
-  ga('create', 'UA-XXXX-Y', 'auto', {
-    // 'name': 'customTracker',  // custom name for tracker
-    'cookieDomain': 'none'       // for development on localhost
-  });
-</script>
+```javascript
+var ENV = {
+  analyticsInsights: {
+    trackers: {
+      googleAnalytics: {
+        webPropertyId: '<id of your web property>',
+        linkid: false, // https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#enhancedlink
+        displayFeatures: false // https://developers.google.com/analytics/devguides/collection/analyticsjs/display-features
+      }
+    }
+  }
+}
 ```
 
-
+Also check, that you have `{{content-for 'head'}}` in your index.html.
 
 ## Tracker object
 Call to `Insights.start` method returns object containing utility functions:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,103 @@
 /* jshint node: true */
-'use strict';
+
+var _defaultConfiguration = {
+  googleAnalytics: {
+    globalVariable: 'ga',
+    webPropertyId: null,
+    cookieDomain: null,
+    cookieName: null,
+    cookieExpires: null,
+    displayFeatures: null,
+    linkid: null
+  }
+};
+
+function mergeConfiguration(defaultConfiguration, config) {
+  var key;
+
+  defaultConfiguration || (defaultConfiguration = {});
+  config || (config = {});
+
+  for (key in defaultConfiguration) {
+    if (!defaultConfiguration.hasOwnProperty(key)) {
+      continue;
+    }
+
+    if (!config[key]) {
+      config[key] = defaultConfiguration[key];
+    }
+  }
+
+  return config
+}
+
+function getGoogleAnalyticsTrackingCode(config) {
+  var scriptArray, key, value, linkid = false, displayFeatures = false, gaConfig = {};
+
+  for (key in config) {
+    if (!config.hasOwnProperty(key)) {
+      continue;
+    }
+
+    value = config[key];
+
+    if (value === null) {
+      continue;
+    }
+
+    if (key === 'linkid') {
+      linkid = value;
+      delete config[key];
+    } else if (key === 'displayFeatures') {
+      displayFeatures = value;
+      delete config[key];
+    }
+
+    gaConfig[key] = config[key];
+  }
+
+  if (Object.keys(gaConfig).length === 0) {
+    gaConfig = "'auto'";
+  } else {
+    gaConfig = JSON.stringify(gaConfig);
+  }
+
+  scriptArray = [
+    "<script>",
+    "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){",
+    "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),",
+    "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)",
+    "})(window,document,'script','//www.google-analytics.com/analytics.js','" + config.globalVariable + "');",
+    "",
+    displayFeatures ? config.globalVariable + "('require', 'displayfeatures');" : "",
+    linkid ? config.globalVariable + "('require', 'linkid', 'linkid.js');" : "",
+    "" + config.globalVariable + "('create', '" + config.webPropertyId + "', " + gaConfig + ");",
+    "</script>"
+  ];
+
+  return scriptArray;
+}
 
 module.exports = {
-  name: 'ember-insights'
+  name: 'ember-insights',
+
+  contentFor: function (type, config) {
+    var content = [], trackers, gaConfig;
+
+    config.analyticsInsights || (config.analyticsInsights = {});
+    trackers = config.analyticsInsights.trackers || (config.analyticsInsights.trackers = {});
+
+    if (trackers.googleAnalytics) {
+      gaConfig = mergeConfiguration(
+        _defaultConfiguration.googleAnalytics,
+        trackers.googleAnalytics || {}
+      );
+
+      if (type === 'head' && gaConfig.webPropertyId !== null) {
+        content = content.concat(getGoogleAnalyticsTrackingCode(gaConfig));
+      }
+    }
+
+    return content.join("\n");
+  }
 };


### PR DESCRIPTION
I see a benefit if we will load <script> tag in the head by the add-on, instead of asking devs to add them manually.