### PR TITLE
v0.4.0: ES6 now

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,7 +3,11 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+var app = new EmberAddon({
+  babel: {
+    comments: false
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/addon/handler.js
+++ b/addon/handler.js
@@ -1,8 +1,8 @@
 import InsightsHandler from './insights-handler';
 
 export default {
-  factory: function(settings) {
-    var insightsHandler = InsightsHandler.factory(settings);
+  factory: (settings) => {
+    let insightsHandler = InsightsHandler.factory(settings);
 
     function defaultDispatcher(type, data, tracker) {
       insightsHandler(type, data, tracker);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,8 @@
 import runtime    from './runtime';
 import middleware from './middleware';
 
-var initializer = (function() {
-  var Addon = {
+var initializer = ( () => {
+  let Addon = {
     isActivated:  false,
     configs:      {},
     settings:     null

--- a/addon/insights-handler.js
+++ b/addon/insights-handler.js
@@ -9,7 +9,7 @@ function transitionHandler(data, tracker, settings) {
   }
 }
 
-function actionHandler(data, tracker, settings = {}) {
+function actionHandler(data, tracker) {
   var actionLabel = data.actionArguments[0];
   var actionValue = data.actionArguments[1];
 

--- a/addon/insights-handler.js
+++ b/addon/insights-handler.js
@@ -9,8 +9,7 @@ function transitionHandler(data, tracker, settings) {
   }
 }
 
-function actionHandler(data, tracker, settings) {
-  settings = settings || {};
+function actionHandler(data, tracker, settings = {}) {
   var actionLabel = data.actionArguments[0];
   var actionValue = data.actionArguments[1];
 

--- a/addon/insights-handler.js
+++ b/addon/insights-handler.js
@@ -1,9 +1,7 @@
 function transitionHandler(data, tracker, settings) {
   switch (settings.trackTransitionsAs) {
     case 'event':
-      tracker.sendEvent(
-        'transition', JSON.stringify({ from: data.prevRouteName, to: data.routeName })
-      );
+      tracker.sendEvent('transition', data.routeName, data.prevRouteName);
       break;
     case 'pageview':
       tracker.trackPageView(data.url);

--- a/addon/insights-handler.js
+++ b/addon/insights-handler.js
@@ -10,15 +10,15 @@ function transitionHandler(data, tracker, settings) {
 }
 
 function actionHandler(data, tracker) {
-  var actionLabel = data.actionArguments[0];
-  var actionValue = data.actionArguments[1];
+  let actionLabel = data.actionArguments[0];
+  let actionValue = data.actionArguments[1];
 
   tracker.sendEvent('action', data.actionName, actionLabel, actionValue);
 }
 
 
 export default {
-  factory: function(settings) {
+  factory: (settings) => {
     function defaultDispatcher(type, data, tracker) {
       switch(type) {
         case 'transition':

--- a/addon/insights-handler.js
+++ b/addon/insights-handler.js
@@ -2,7 +2,7 @@ function transitionHandler(data, tracker, settings) {
   switch (settings.trackTransitionsAs) {
     case 'event':
       tracker.sendEvent(
-        'transition', JSON.stringify({ from: data.oldRouteName, to: data.routeName })
+        'transition', JSON.stringify({ from: data.prevRouteName, to: data.routeName })
       );
       break;
     case 'pageview':

--- a/addon/matcher.js
+++ b/addon/matcher.js
@@ -1,16 +1,16 @@
 /* global Ember */
 
 function groupMatches(group, routeName, eventType, eventValueToMatch) {
-  var routeNameNoIndex = routeName.replace('.index', '');
+  let routeNameNoIndex = routeName.replace('.index', '');
 
-  var allKey = 'ALL_' + eventType.toUpperCase() + 'S';
-  var all = group.insights.getWithDefault(allKey, false);
+  let allKey = 'ALL_' + eventType.toUpperCase() + 'S';
+  let all = group.insights.getWithDefault(allKey, false);
 
   if ( checkInAll(all, eventType, eventValueToMatch, routeNameNoIndex) ) {
     return allKey;
   }
 
-  var toMatch = getSearchingPaths(eventType, routeName, routeNameNoIndex, eventValueToMatch);
+  let toMatch = getSearchingPaths(eventType, routeName, routeNameNoIndex, eventValueToMatch);
 
   for (var i = 0, len = toMatch.length; i < len; i++) {
     var path   = toMatch[i][0];
@@ -24,19 +24,20 @@ function groupMatches(group, routeName, eventType, eventValueToMatch) {
 }
 
 function getSearchingPaths(eventType, routeName, routeNameNoIndex, eventValueToMatch) {
-  if (eventType === 'transition') {
-    return [
-      ['TRANSITIONS', routeName       ],
-      ['TRANSITIONS', routeNameNoIndex],
-      ['MAP.' + routeName        + '.ACTIONS', 'TRANSITION'],
-      ['MAP.' + routeNameNoIndex + '.ACTIONS', 'TRANSITION']
-    ];
-  } else if (eventType === 'action') {
-    return [
-      ['ACTIONS', eventValueToMatch],
-      ['MAP.' + routeName        + '.ACTIONS', eventValueToMatch],
-      ['MAP.' + routeNameNoIndex + '.ACTIONS', eventValueToMatch]
-    ];
+  switch (eventType) {
+    case 'transition':
+      return [
+        ['TRANSITIONS', routeName       ],
+        ['TRANSITIONS', routeNameNoIndex],
+        ['MAP.' + routeName        + '.ACTIONS', 'TRANSITION'],
+        ['MAP.' + routeNameNoIndex + '.ACTIONS', 'TRANSITION']
+      ];
+    case 'action':
+      return [
+        ['ACTIONS', eventValueToMatch],
+        ['MAP.' + routeName        + '.ACTIONS', eventValueToMatch],
+        ['MAP.' + routeNameNoIndex + '.ACTIONS', eventValueToMatch]
+      ];
   }
 }
 

--- a/addon/middleware.js
+++ b/addon/middleware.js
@@ -35,17 +35,16 @@ export default {
     }
 
     // middleware for actions
-    function actionMiddleware(actionName) {
+    function actionMiddleware(actionName, ...actionArguments) {
       // use original implementation if addon is not activated
-      if (!addon.isActivated) { this._super.apply(this, arguments); return; }
+      if (!addon.isActivated) { this._super(...arguments); return; }
 
       let appController   = this.container.lookup('controller:application');
       let routeName       = appController.get('currentRouteName');
       let route           = this.container.lookup('route:' + routeName);
       let url             = this.container.lookup('router:main').get('url');
-      let actionArguments = [].slice.call(arguments, 1);
 
-      Ember.run.schedule('afterRender', this, function() {
+      Ember.run.schedule('afterRender', this, () => {
         _handle('action', {
           actionName:       actionName,
           actionArguments:  actionArguments,
@@ -55,20 +54,20 @@ export default {
         });
       });
 
-      this._super.apply(this, arguments);
+      this._super(...arguments);
     }
 
     // middleware for transitions
     function transitionMiddleware() {
       // use original implementation if addon is not activated
-      if (!addon.isActivated) { this._super.apply(this, arguments); return; }
+      if (!addon.isActivated) { this._super(...arguments); return; }
 
       let appController  = this.container.lookup('controller:application');
       let prevRouteName  = appController.get('currentRouteName');
       let prevUrl        = (prevRouteName ? this.get('url') : '');
       let newRouteName   = arguments[0][arguments[0].length-1].name;
 
-      Ember.run.schedule('afterRender', this, function() {
+      Ember.run.schedule('afterRender', this, () => {
         _handle('transition', {
           route:         this.container.lookup('route:' + newRouteName),
           routeName:     newRouteName,
@@ -78,7 +77,7 @@ export default {
         });
       });
 
-      this._super.apply(this, arguments);
+      this._super(...arguments);
     }
 
     // start catching actions

--- a/addon/middleware.js
+++ b/addon/middleware.js
@@ -25,7 +25,7 @@ export default {
         var isMapped = (matchedGroups.length ? ' SEND' : ' TRAP');
         var template = { prompt: "Ember-Insights%@: '%@'", p1: " from '%@':'%@'", p2: " %@ '%@':'%@'" };
         var msg = Ember.String.fmt(template.prompt, isMapped, eventName);
-        if (data.oldRouteName) { msg += Ember.String.fmt(template.p1, data.oldRouteName, data.oldUrl); }
+        if (data.prevRouteName) { msg += Ember.String.fmt(template.p1, data.prevRouteName, data.oldUrl); }
         var prep = (type === 'action') ? 'action from' : 'to';
         if (data.routeName)    { msg += Ember.String.fmt(template.p2, prep, data.routeName, data.url); }
 
@@ -60,24 +60,22 @@ export default {
       // use original implementation if addon is not activated
       if (!addon.isActivated) { this._super.apply(this, arguments); return; }
 
-      var appController = this.container.lookup('controller:application');
-      var oldRouteName  = appController.get('currentRouteName');
-      var oldUrl        = oldRouteName ? this.get('url') : '';
+      var appController  = this.container.lookup('controller:application');
+      var prevRouteName  = appController.get('currentRouteName');
+      var prevUrl        = (prevRouteName ? this.get('url') : '');
+      var newRouteName   = arguments[0][arguments[0].length-1].name;
 
-      this._super.apply(this, arguments); // bubble event back to the Ember engine
-
-      var newRouteName = appController.get('currentRouteName');
-
-      Ember.run.scheduleOnce('routerTransitions', this, function() {
-        var newUrl = (this.get('url') || '/');
+      Ember.run.schedule('afterRender', this, function() {
         _handle('transition', {
-          route:        this.container.lookup('route:' + newRouteName),
-          routeName:    newRouteName,
-          oldRouteName: oldRouteName,
-          url:          newUrl,
-          oldUrl:       oldUrl
+          route:         this.container.lookup('route:' + newRouteName),
+          routeName:     newRouteName,
+          prevRouteName: prevRouteName,
+          url:           (this.get('url') || '/'),
+          prevUrl:       prevUrl
         });
       });
+
+      this._super.apply(this, arguments);
     }
 
     // start catching actions

--- a/addon/middleware.js
+++ b/addon/middleware.js
@@ -2,9 +2,9 @@
 import { getMatchedGroups, processMatchedGroups } from './matcher';
 
 export default {
-  use: function(addon) {
+  use: (addon) => {
     function _handle(type, data) {
-      var eventName, valueToMatch;
+      let eventName, valueToMatch;
 
       switch (type) {
         case 'transition':
@@ -17,34 +17,33 @@ export default {
           break;
       }
 
-      // look up for all matching insight mappings
-      var matchedGroups = getMatchedGroups(addon.settings.mappings, data.routeName, type, valueToMatch);
+      let matchedGroups = getMatchedGroups(addon.settings.mappings, data.routeName, type, valueToMatch);
 
-      // drop a line to the console log
+      // drop a line to the Ember.debug
       if (addon.settings.debug) {
-        var isMapped = (matchedGroups.length ? ' SEND' : ' TRAP');
-        var template = { prompt: "Ember-Insights%@: '%@'", p1: " from '%@':'%@'", p2: " %@ '%@':'%@'" };
-        var msg = Ember.String.fmt(template.prompt, isMapped, eventName);
-        if (data.prevRouteName) { msg += Ember.String.fmt(template.p1, data.prevRouteName, data.oldUrl); }
-        var prep = (type === 'action') ? 'action from' : 'to';
+        let isMapped = (matchedGroups.length ? ' SEND' : ' TRAP');
+        let template = { prompt: "Ember-Insights%@: '%@'", p1: " from '%@':'%@'", p2: " %@ '%@':'%@'" };
+        let msg = Ember.String.fmt(template.prompt, isMapped, eventName);
+        if (data.prevRouteName) { msg += Ember.String.fmt(template.p1, data.prevRouteName, data.prevUrl); }
+        let prep = (type === 'action') ? 'action from' : 'to';
         if (data.routeName)    { msg += Ember.String.fmt(template.p2, prep, data.routeName, data.url); }
 
         Ember.debug(msg);
       }
+
       processMatchedGroups(matchedGroups, addon.settings, type, data);
     }
-
 
     // middleware for actions
     function actionMiddleware(actionName) {
       // use original implementation if addon is not activated
       if (!addon.isActivated) { this._super.apply(this, arguments); return; }
 
-      var appController   = this.container.lookup('controller:application');
-      var routeName       = appController.get('currentRouteName');
-      var route           = this.container.lookup('route:' + routeName);
-      var url             = this.container.lookup('router:main').get('url');
-      var actionArguments = [].slice.call(arguments, 1);
+      let appController   = this.container.lookup('controller:application');
+      let routeName       = appController.get('currentRouteName');
+      let route           = this.container.lookup('route:' + routeName);
+      let url             = this.container.lookup('router:main').get('url');
+      let actionArguments = [].slice.call(arguments, 1);
 
       Ember.run.schedule('afterRender', this, function() {
         _handle('action', {
@@ -64,10 +63,10 @@ export default {
       // use original implementation if addon is not activated
       if (!addon.isActivated) { this._super.apply(this, arguments); return; }
 
-      var appController  = this.container.lookup('controller:application');
-      var prevRouteName  = appController.get('currentRouteName');
-      var prevUrl        = (prevRouteName ? this.get('url') : '');
-      var newRouteName   = arguments[0][arguments[0].length-1].name;
+      let appController  = this.container.lookup('controller:application');
+      let prevRouteName  = appController.get('currentRouteName');
+      let prevUrl        = (prevRouteName ? this.get('url') : '');
+      let newRouteName   = arguments[0][arguments[0].length-1].name;
 
       Ember.run.schedule('afterRender', this, function() {
         _handle('transition', {

--- a/addon/middleware.js
+++ b/addon/middleware.js
@@ -40,18 +40,22 @@ export default {
       // use original implementation if addon is not activated
       if (!addon.isActivated) { this._super.apply(this, arguments); return; }
 
-      var appController = this.container.lookup('controller:application');
-      var routeName     = appController.get('currentRouteName');
+      var appController   = this.container.lookup('controller:application');
+      var routeName       = appController.get('currentRouteName');
+      var route           = this.container.lookup('route:' + routeName);
+      var url             = this.container.lookup('router:main').get('url');
+      var actionArguments = [].slice.call(arguments, 1);
 
-      _handle('action', {
-        actionName:       actionName,
-        actionArguments:  [].slice.call(arguments, 1),
-        route:            this.container.lookup('route:' + routeName),
-        routeName:        this.container.lookup('controller:application').get('currentRouteName'),
-        url:              this.container.lookup('router:main').get('url')
+      Ember.run.schedule('afterRender', this, function() {
+        _handle('action', {
+          actionName:       actionName,
+          actionArguments:  actionArguments,
+          route:            route,
+          routeName:        routeName,
+          url:              url
+        });
       });
 
-      // bubble event back to the Ember engine
       this._super.apply(this, arguments);
     }
 

--- a/addon/optparse.js
+++ b/addon/optparse.js
@@ -14,15 +14,16 @@ export default {
     return opts;
   },
 
+  configureOpts: ['debug', 'trackerFactory', 'trackTransitionsAs', 'updateDocumentLocationOnTransitions'],
+
   hasConfigureOpts: function(opts) {
-    var configureOpts = ['debug', 'trackerFactory', 'trackTransitionsAs', 'updateDocumentLocationOnTransitions'];
-    var result = Ember.A(configureOpts).find(function(e) { return opts.hasOwnProperty(e); });
+    let result = Ember.A(this.configureOpts).find( (e) => opts.hasOwnProperty(e) );
     return result;
   },
 
-  defaultTrackOpts: function(opts) {
-    var defaultOpts = { insights: { ALL_TRANSITIONS: true, ALL_ACTIONS: true } };
-    opts = (opts || defaultOpts);
+  defaultInsightsMapping: { insights: { ALL_TRANSITIONS: true, ALL_ACTIONS: true } },
+
+  defaultTrackOpts: function(opts = this.defaultInsightsMapping) {
     var assert = (typeof opts.insights === 'object');
     Ember.assert("Can't find `insights` property inside", assert);
     return opts;

--- a/addon/optparse.js
+++ b/addon/optparse.js
@@ -17,7 +17,7 @@ export default {
   configureOpts: ['debug', 'trackerFactory', 'trackTransitionsAs', 'updateDocumentLocationOnTransitions'],
 
   hasConfigureOpts: function(opts) {
-    let result = Ember.A(this.configureOpts).find( (e) => opts.hasOwnProperty(e) );
+    let result = Ember.A(this.configureOpts).find( (e) => e in opts );
     return result;
   },
 

--- a/addon/optparse.js
+++ b/addon/optparse.js
@@ -24,7 +24,7 @@ export default {
   defaultInsightsMapping: { insights: { ALL_TRANSITIONS: true, ALL_ACTIONS: true } },
 
   defaultTrackOpts: function(opts = this.defaultInsightsMapping) {
-    var assert = (typeof opts.insights === 'object');
+    let assert = (typeof opts.insights === 'object');
     Ember.assert("Can't find `insights` property inside", assert);
     return opts;
   },
@@ -34,7 +34,7 @@ export default {
   },
 
   mergeTrackerOpts: function(opts, basicOpts) {
-    var assert;
+    let assert;
 
     opts.debug = (opts.debug === undefined ? true : opts.debug);
 
@@ -61,7 +61,7 @@ export default {
 
   dispatcherOpts: function(opts) {
     opts.dispatch = (opts.dispatch || DefaultHandler.factory(opts));
-    var assert = (typeof opts.dispatch === 'function');
+    let assert = (typeof opts.dispatch === 'function');
     Ember.assert("'dispatch' should be a function", assert);
 
     return opts;

--- a/addon/runtime.js
+++ b/addon/runtime.js
@@ -48,8 +48,7 @@ export default function(addon) {
 
       return this;
     },
-    start: function(env) {
-      env = (env || 'default');
+    start: function(env = 'default') {
       addon.settings = addon.configs[env];
       Ember.assert("can't find settings for '" + env + "' environment", addon.settings);
       Ember.assert("can't start without specified mappings", addon.settings.mappings.length > 0);

--- a/addon/runtime.js
+++ b/addon/runtime.js
@@ -4,7 +4,7 @@ import { ConsoleTracker, GoogleTracker } from './trackers';
 
 
 export default function(addon) {
-  var _settings = {}; // current configuration stage
+  let _settings = {}; // current configuration stage
   var runtime = {
     configure: function() {
       optparse.defaultConfigureOpts(arguments);
@@ -12,8 +12,8 @@ export default function(addon) {
         if (!(arguments[2] && arguments[2].append)) {
           _settings = {};
         }
-        var env         = arguments[0];
-        var settings    = arguments[1];
+        let env         = arguments[0];
+        let settings    = arguments[1];
         _settings[env]  = settings;
 
         // apply defaults
@@ -23,10 +23,9 @@ export default function(addon) {
         settings.mappings  = [];
         addon.configs[env] = settings;
       } else if (typeof arguments[0] === 'object') {
-        var envs = arguments[0];
-        var self = this;
-        Object.keys(envs).forEach(function(envName) {
-          self.configure(envName, envs[envName], { append: true });
+        let envs = arguments[0];
+        Object.keys(envs).forEach( (envName) => {
+          this.configure(envName, envs[envName], { append: true });
         });
       }
       return this;
@@ -34,11 +33,11 @@ export default function(addon) {
     track: function(mapping) {
       mapping = optparse.defaultTrackOpts(mapping);
 
-      Object.keys(_settings).forEach(function(settingsName) {
-        var newMapping = Ember.$.extend(true, {}, mapping);
+      Object.keys(_settings).forEach( (settingsName) => {
+        let newMapping = Ember.$.extend(true, {}, mapping);
         newMapping.insights = Ember.Object.create(newMapping.insights);
 
-        var setting = _settings[settingsName];
+        let setting = _settings[settingsName];
         // apply defaults
         optparse.mergeTrackerOpts(newMapping, setting);
         optparse.dispatcherOpts(newMapping);

--- a/addon/trackers/abstract-tracker.js
+++ b/addon/trackers/abstract-tracker.js
@@ -5,7 +5,7 @@ function notYetImplemented(signature) {
   Ember.warn("function '" + signature + "' is not yet implemented");
 }
 
-var AbstractTracker = Class.extend({
+let AbstractTracker = Class.extend({
   isTracker: function() {
     notYetImplemented('isTracker()');
   },

--- a/addon/trackers/console.js
+++ b/addon/trackers/console.js
@@ -2,13 +2,13 @@
 import AbstractTracker from './abstract-tracker';
 
 function logger(label, params) {
-  var message = Ember.String.fmt('LOG: Ember-Insights: ConsoleTracker.%@(%@)', label, params);
+  let message = Ember.String.fmt('LOG: Ember-Insights: ConsoleTracker.%@(%@)', label, params);
   Ember.Logger.log(message);
 }
 
 export default {
   factory: function() {
-    var Tracker = AbstractTracker.extend({
+    let Tracker = AbstractTracker.extend({
       getTracker: function() {
         return logger;
       },

--- a/addon/trackers/google.js
+++ b/addon/trackers/google.js
@@ -21,12 +21,12 @@ function setFields(tracker, namespace, fields) {
 function _buildFactory(trackerOptions) {
   trackerOptions = trackerOptions || {};
 
-  return function(settings) { // jshint ignore:line
-    function tracker() { return trackerFun(trackerOptions.trackerFun || 'ga'); }
-    var namespace = trackingNamespace(trackerOptions.name || '');
+  return function(/* settings */) {
+    let tracker = () => trackerFun(trackerOptions.trackerFun || 'ga');
+    let namespace = trackingNamespace(trackerOptions.name || '');
 
     // Runtime conveniences as a wrapper for tracker function
-    var Tracker = AbstractTracker.extend({
+    let Tracker = AbstractTracker.extend({
       init: function() {
         if (trackerOptions.fields) {
           setFields(tracker(), namespace, trackerOptions.fields);
@@ -46,7 +46,7 @@ function _buildFactory(trackerOptions) {
         tracker()(namespace('send'), fields);
       },
       sendEvent: function(category, action, label, value) {
-        var fields = {
+        let fields = {
           hitType:      'event',
           eventCategory: category,
           eventAction:   action,
@@ -58,7 +58,7 @@ function _buildFactory(trackerOptions) {
       trackPageView: function(path, fields) {
         fields = fields || {};
         if (!path) {
-          var loc = window.location;
+          let loc = window.location;
           path = loc.hash ? loc.hash.substring(1) : (loc.pathname + loc.search);
         }
         tracker()(namespace('send'), 'pageview', path, fields);

--- a/addon/trackers/google.js
+++ b/addon/trackers/google.js
@@ -9,9 +9,7 @@ function trackerFun(trackerFun, global) {
 }
 
 function trackingNamespace(name) {
-  return function(action) {
-    return (name ? name + '.' : '') + action;
-  };
+  return (action) => (name ? name + '.' : '') + action;
 }
 
 function setFields(tracker, namespace, fields) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "google analytics"
   ],
   "dependencies": {
-    "ember-cli-babel": "^4.0.0"
+    "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/initializers/insights.js
+++ b/tests/dummy/app/initializers/insights.js
@@ -10,7 +10,7 @@ export default {
     Insights.configure('development', {
       // trackerFactory: Insights.ConsoleTracker.factory
 
-      // trackerFactory: Insights.GoogleTracker.factory
+      trackerFactory: Insights.GoogleTracker.factory
       // trackerFactory: Insights.GoogleTracker.with({
       //   trackerFun: 'ga', name: ''
       // })

--- a/tests/dummy/app/routes/main/record.js
+++ b/tests/dummy/app/routes/main/record.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 
   model: function(params) {
-    return Ember.Object.create({recordData: params.ident});
+    // return Ember.Object.create({recordData: params.ident});
   }
 
 });

--- a/tests/dummy/app/routes/outer/inner/nested.js
+++ b/tests/dummy/app/routes/outer/inner/nested.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 
   model: function(params) {
-    return Ember.Object.create({data: params.idd});
+    // return Ember.Object.create({nestedData: params.ident});
   }
 
 });

--- a/tests/unit/handlers/insights-transition-handler-test.js
+++ b/tests/unit/handlers/insights-transition-handler-test.js
@@ -13,11 +13,10 @@ describe('Insights Handler in context of #transitionHandler', function() {
         prevRouteName: 'outer.inner.nested', routeName: 'outer.inner.index',
       };
       var tracker = {
-        sendEvent: function(type, json) {
-          var parsed = JSON.parse(json);
-          expect(type).to.equal('transition');
-          expect(parsed.from).to.equal('outer.inner.nested');
-          expect(parsed.to).to.equal('outer.inner.index');
+        sendEvent: function(category, action, label) {
+          expect(category).to.equal('transition');
+          expect(action).to.equal('outer.inner.index');
+          expect(label).to.equal('outer.inner.nested');
           done();
         }
       };

--- a/tests/unit/handlers/insights-transition-handler-test.js
+++ b/tests/unit/handlers/insights-transition-handler-test.js
@@ -10,7 +10,7 @@ describe('Insights Handler in context of #transitionHandler', function() {
     it('as an "event"', function(done) {
       var settings = { trackTransitionsAs: 'event'};
       var data = {
-        oldRouteName: 'outer.inner.nested', routeName: 'outer.inner.index',
+        prevRouteName: 'outer.inner.nested', routeName: 'outer.inner.index',
       };
       var tracker = {
         sendEvent: function(type, json) {


### PR DESCRIPTION
#### changelog

- #119 [PERFORMANCE] Deferred 'transitionMiddleware' and 'actionMiddleware' (using 'afterRender' queue);
- Moving to ES6, using Arrows, let, Rest, default parameters and so on;
- #9, #98 [CHANGES] `tracker.sendEvent('transition', data.routeName, data.prevRouteName)` in case of `trackTransitionsAs: 'event'`;